### PR TITLE
Remove gxx compiler specification for C++ extension compatibility

### DIFF
--- a/install_python.sh
+++ b/install_python.sh
@@ -4,8 +4,6 @@ set -e
 
 # This is being run as root and so sudo is not needed
 
-CXX_VERSION="$(which gcc)"
-
 function download_cpython () {
     # 1: the version tag
     printf "\n### Downloading CPython source as Python-%s.tgz\n" "${1}"
@@ -28,33 +26,28 @@ function set_num_processors {
 function build_cpython () {
     # 1: the prefix to be passed to configure
     #    c.f. https://docs.python.org/3/using/unix.html#python-related-paths-and-files
-    # 2: the path to the version of gcc to be used
-    # 3: the Python version being built
+    # 2: the Python version being built
 
     # https://docs.python.org/3/using/unix.html#building-python
     # https://github.com/python/cpython/blob/3.7/README.rst
     # https://github.com/python/cpython/blob/3.6/README.rst
     printf "\n### ./configure\n"
-    if [[ "${3}" > "3.7.0"  ]]; then
+    if [[ "${2}" > "3.7.0"  ]]; then
         # --with-threads is removed in Python 3.7 (threading already on)
         ./configure --prefix="${1}" \
             --exec_prefix="${1}" \
-            --with-cxx-main="${2}" \
             --enable-optimizations \
             --with-lto \
             --enable-loadable-sqlite-extensions \
-            --enable-ipv6 \
-            CXX="${2}"
+            --enable-ipv6
     else
         ./configure --prefix="${1}" \
             --exec_prefix="${1}" \
-            --with-cxx-main="${2}" \
             --enable-optimizations \
             --with-lto \
             --enable-loadable-sqlite-extensions \
             --enable-ipv6 \
-            --with-threads \
-            CXX="${2}"
+            --with-threads
     fi
     printf "\n### make -j%s\n" "${NPROC}"
     make -j"${NPROC}"
@@ -114,7 +107,7 @@ function main() {
     NPROC="$(set_num_processors)"
     download_cpython "${PYTHON_VERSION_TAG}"
     cd Python-"${PYTHON_VERSION_TAG}"
-    build_cpython /usr "${CXX_VERSION}" "${PYTHON_VERSION_TAG}"
+    build_cpython /usr "${PYTHON_VERSION_TAG}"
     update_pip
 
     if [[ "${LINK_PYTHON_TO_PYTHON3}" -eq 1 ]]; then


### PR DESCRIPTION
The use of the `--with-cxx-main` configure flag is removed along with explicit setting of `CXX`.

The motivation for this came from the inability to build [`iminuit`](https://pypi.org/project/iminuit/) in the Docker container with the error

```python-traceback
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File
"/home/docker/.local/lib/python3.6/site-packages/iminuit/__init__.py",
line 27, in <module>
    from ._libiminuit import Minuit
ImportError:
/home/docker/.local/lib/python3.6/site-packages/iminuit/_libiminuit.cpython-36m-x86_64-linux-gnu.so:
undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE
```

This seems to have come from having a mismatch between the CPython build compiler (which was `gcc` in this instance) and the compiler used to build the C++ extension modules of `iminuit` (which was presumably `g++`) due to the hard coding with configure. Following the very helpful and detailed information on the `--with-cxx-main` flag from the old Python 2.7 SVN trunk [`README`](https://svn.python.org/projects/python/trunk/README) this became more clear that not only was `--with-cxx-main` not wanted but that setting `CXX` was unnecessary especially as `c++` and `g++` are the same on Ubuntu:

>        --with-cxx-main=<compiler>: If you plan to use C++ extension modules,
>        then -- on some platforms -- you need to compile python's main()
>        function with the C++ compiler. With this option, make will use
>        <compiler> to compile main() *and* to link the python executable.
>        It is likely that the resulting executable depends on the C++
>        runtime library of <compiler>. (The default is --without-cxx-main.)
>
>        There are platforms that do not require you to build Python
>        with a C++ compiler in order to use C++ extension modules.
>        E.g., x86 Linux with ELF shared binaries and GCC 3.x, 4.x is such
>        a platform. We recommend that you configure Python
>        --without-cxx-main on those platforms because a mismatch
>        between the C++ compiler version used to build Python and to
>        build a C++ extension module is likely to cause a crash at
>        runtime.
>
>        The Python installation also stores the variable CXX that
>        determines, e.g., the C++ compiler distutils calls by default
>        to build C++ extensions. If you set CXX on the configure command
>        line to any string of non-zero length, then configure won't
>        change CXX. If you do not preset CXX but pass
>        --with-cxx-main=<compiler>, then configure sets CXX=<compiler>.
>        In all other cases, configure looks for a C++ compiler by
>        some common names (c++, g++, gcc, CC, cxx, cc++, cl) and sets
>        CXX to the first compiler it finds. If it does not find any
>        C++ compiler, then it sets CXX="".
>
>        Similarly, if you want to change the command used to link the
>        python executable, then set LINKCC on the configure command line.

Also of some note is [CPython Issue 23644: `g++` module compile fails with ‘_Atomic’ does not name a type](https://bugs.python.org/issue23644) as it enforces the idea of not trying to force `CXX` versions.

A final note, if the `CC` and `CXX` are left unset the values that were used can be determined from `sysconfig` using the following:

```
python3 -c "import sysconfig; print(sysconfig.get_config_vars('CC', 'CXX', 'LDCXXSHARED'))"
```

which in this container yields

```
['gcc -pthread', 'g++ -pthread', 'g++ -pthread -shared']
```

Special thanks goes to @daritter and @henryiii for their [help in understanding and fixing the issue](https://gitter.im/HSF/PyHEP?at=5ccf87bc8790b0307e5aa7e9).