### PR TITLE
Use COPY for best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 
-ADD install_python.sh install_python.sh
+COPY install_python.sh install_python.sh
 RUN bash install_python.sh ${PYTHON_VERSION_TAG} ${LINK_PYTHON_TO_PYTHON3} && \
     rm -r install_python.sh Python-${PYTHON_VERSION_TAG}
 


### PR DESCRIPTION
# Description

`COPY` is considered best practice over using `ADD` unless `ADD`'s tar and remote URL capabilities are needed.
c.f.
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
- https://stackoverflow.com/a/24958548/8931942

Thanks to @dguest for a conversation about this that proved insightful