### PR TITLE
Update Python 3.7 to Python 3.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root
 
 SHELL [ "/bin/bash", "-c" ]
 
-ARG PYTHON_VERSION_TAG=3.7.3
+ARG PYTHON_VERSION_TAG=3.7.4
 ARG LINK_PYTHON_TO_PYTHON3=1
 
 # Existing lsb_release causes issues with modern installations of Python3

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ all: image py_3.6.8
 image:
 	docker build -f Dockerfile \
 	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
-	--build-arg PYTHON_VERSION_TAG=3.7.3 \
+	--build-arg PYTHON_VERSION_TAG=3.7.4 \
 	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
 	-t matthewfeickert/docker-python3-ubuntu:latest \
-	-t matthewfeickert/docker-python3-ubuntu:3.7.3 \
+	-t matthewfeickert/docker-python3-ubuntu:3.7.4 \
 	--compress .
 
 py_3.6.8:

--- a/install_python.sh
+++ b/install_python.sh
@@ -94,7 +94,7 @@ function main() {
     # 1: the Python version tag
     # 2: bool of if should symlink python and pip to python3 versions
 
-    PYTHON_VERSION_TAG=3.7.3
+    PYTHON_VERSION_TAG=3.7.4
     LINK_PYTHON_TO_PYTHON3=0 # By default don't link so as to reserve python for Python 2
     if [[ $# -gt 0 ]]; then
         PYTHON_VERSION_TAG="${1}"


### PR DESCRIPTION
Use [Python release 3.7.4](https://www.python.org/downloads/release/python-374/) in the Python 3.7 Docker image.