### PR TITLE
Update Python 3 to Python 3.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root
 
 SHELL [ "/bin/bash", "-c" ]
 
-ARG PYTHON_VERSION_TAG=3.7.4
+ARG PYTHON_VERSION_TAG=3.8.0
 ARG LINK_PYTHON_TO_PYTHON3=1
 
 # Existing lsb_release causes issues with modern installations of Python3

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
 default: image
 
-all: image py_3.6.8
+all: image py_3.6.8 py_3.7.4
 
 image:
 	docker build -f Dockerfile \
 	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
-	--build-arg PYTHON_VERSION_TAG=3.7.4 \
+	--build-arg PYTHON_VERSION_TAG=3.8.0 \
 	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
 	-t matthewfeickert/docker-python3-ubuntu:latest \
+	-t matthewfeickert/docker-python3-ubuntu:3.8.0 \
+	--compress .
+
+py_3.7.4:
+	docker build -f Dockerfile \
+	--cache-from matthewfeickert/docker-python3-ubuntu:3.7.4 \
+	--build-arg PYTHON_VERSION_TAG=3.7.4 \
+	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
 	-t matthewfeickert/docker-python3-ubuntu:3.7.4 \
 	--compress .
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python3 on Ubuntu Docker
 
-Dockerfile for image built off [Ubuntu 18.04](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/18.04) containing [Python 3.7](https://www.python.org/downloads/release/python-372/) ([Python 3.6](https://www.python.org/downloads/release/python-368/)) built from source
+Dockerfile for image built off [Ubuntu 18.04](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/18.04) containing [Python 3.8](https://www.python.org/downloads/release/python-380/) ([Python 3.6](https://www.python.org/downloads/release/python-368/), [Python 3.7](https://www.python.org/downloads/release/python-374/)) built from source
 
 [![Docker Automated build](https://img.shields.io/docker/automated/matthewfeickert/docker-python3-ubuntu.svg)](https://hub.docker.com/r/matthewfeickert/docker-python3-ubuntu/)
 [![Docker Build Status](https://img.shields.io/docker/build/matthewfeickert/docker-python3-ubuntu.svg)](https://hub.docker.com/r/matthewfeickert/docker-python3-ubuntu/builds/)
@@ -37,4 +37,4 @@ Dockerfile for image built off [Ubuntu 18.04](https://wiki.ubuntu.com/BionicBeav
 
 ### From source
 
-- Python 3.7 (3.6)
+- Python 3.8 (3.6, 3.7)

--- a/install_python.sh
+++ b/install_python.sh
@@ -29,6 +29,7 @@ function build_cpython () {
     # 2: the Python version being built
 
     # https://docs.python.org/3/using/unix.html#building-python
+    # https://github.com/python/cpython/blob/3.8/README.rst
     # https://github.com/python/cpython/blob/3.7/README.rst
     # https://github.com/python/cpython/blob/3.6/README.rst
     printf "\n### ./configure\n"
@@ -51,6 +52,8 @@ function build_cpython () {
     fi
     printf "\n### make -j%s\n" "${NPROC}"
     make -j"${NPROC}"
+    printf "\n### make -j%s test\n" "${NPROC}"
+    make -j"${NPROC}" test
     printf "\n### make install\n"
     make install
 }
@@ -94,7 +97,7 @@ function main() {
     # 1: the Python version tag
     # 2: bool of if should symlink python and pip to python3 versions
 
-    PYTHON_VERSION_TAG=3.7.4
+    PYTHON_VERSION_TAG=3.8.0
     LINK_PYTHON_TO_PYTHON3=0 # By default don't link so as to reserve python for Python 2
     if [[ $# -gt 0 ]]; then
         PYTHON_VERSION_TAG="${1}"


### PR DESCRIPTION
Use [Python release 3.8.0](https://www.python.org/downloads/release/python-380/) as the default Python 3 Docker image.