### PR TITLE
Update Python 3.8 to 3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root
 
 SHELL [ "/bin/bash", "-c" ]
 
-ARG PYTHON_VERSION_TAG=3.8.0
+ARG PYTHON_VERSION_TAG=3.8.1
 ARG LINK_PYTHON_TO_PYTHON3=1
 
 # Existing lsb_release causes issues with modern installations of Python3

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
 default: image
 
-all: image py_3.6.8 py_3.7.4
+all: image py_3.8.0 py_3.7.4 py_3.6.8
 
 image:
+	docker build -f Dockerfile \
+	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
+	--build-arg PYTHON_VERSION_TAG=3.8.1 \
+	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
+	-t matthewfeickert/docker-python3-ubuntu:latest \
+	-t matthewfeickert/docker-python3-ubuntu:3.8.1 \
+	--compress .
+
+py_3.8.0:
 	docker build -f Dockerfile \
 	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
 	--build-arg PYTHON_VERSION_TAG=3.8.0 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python3 on Ubuntu Docker
 
-Dockerfile for image built off [Ubuntu 18.04](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/18.04) containing [Python 3.8](https://www.python.org/downloads/release/python-380/) ([Python 3.6](https://www.python.org/downloads/release/python-368/), [Python 3.7](https://www.python.org/downloads/release/python-374/)) built from source
+Dockerfile for image built off [Ubuntu 18.04](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/18.04) containing [Python 3.8](https://www.python.org/downloads/release/python-381/) ([Python 3.6](https://www.python.org/downloads/release/python-368/), [Python 3.7](https://www.python.org/downloads/release/python-374/)) built from source
 
 [![Docker Automated build](https://img.shields.io/docker/automated/matthewfeickert/docker-python3-ubuntu.svg)](https://hub.docker.com/r/matthewfeickert/docker-python3-ubuntu/)
 [![Docker Build Status](https://img.shields.io/docker/build/matthewfeickert/docker-python3-ubuntu.svg)](https://hub.docker.com/r/matthewfeickert/docker-python3-ubuntu/builds/)

--- a/install_python.sh
+++ b/install_python.sh
@@ -15,7 +15,7 @@ function download_cpython () {
 function set_num_processors {
     # Set the number of processors used for build
     # to be 1 less than are available
-    if [[ -f "$(which nproc)" ]]; then
+    if [[ -f "$(command -v nproc)" ]]; then
         NPROC="$(nproc)"
     else
         NPROC="$(grep -c '^processor' /proc/cpuinfo)"
@@ -74,16 +74,16 @@ function symlink_python_to_python3 {
     local python_version
     python_version="$(python3 --version)"
     local which_python
-    which_python="$(which python3)${python_version:8:-2}"
+    which_python="$(command -v python3)${python_version:8:-2}"
     local which_pip
-    which_pip="$(which pip3)"
+    which_pip="$(command -v pip3)"
 
     # symlink python to python3
     printf "\n### ln -s -f %s %s\n" "${which_python}" "${which_python::-3}"
     ln -s -f "${which_python}" "${which_python::-3}"
 
     # symlink pip to pip3 if no pip exists or it is a different version than pip3
-    if [[ ! -z "$(which pip)" ]]; then
+    if [[ -n "$(command -v pip)" ]]; then
         if [[ "$(pip --version)" = "$(pip3 --version)" ]]; then
             return 0
         fi

--- a/install_python.sh
+++ b/install_python.sh
@@ -97,7 +97,7 @@ function main() {
     # 1: the Python version tag
     # 2: bool of if should symlink python and pip to python3 versions
 
-    PYTHON_VERSION_TAG=3.8.0
+    PYTHON_VERSION_TAG=3.8.1
     LINK_PYTHON_TO_PYTHON3=0 # By default don't link so as to reserve python for Python 2
     if [[ $# -gt 0 ]]; then
         PYTHON_VERSION_TAG="${1}"


### PR DESCRIPTION
Use [Python release 3.8.1](https://www.python.org/downloads/release/python-381/) as the default Python 3 Docker image.

Additionally resolve issues 

* https://github.com/koalaman/shellcheck/wiki/SC2230
* https://github.com/koalaman/shellcheck/wiki/SC2236

raised by Shellcheck.