### PR TITLE
feat: Update Python 3.8 to 3.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ARG LINK_PYTHON_TO_PYTHON3=1
 # https://github.com/pypa/pip/issues/4924#issuecomment-435825490
 # Set (temporarily) DEBIAN_FRONTEND to avoid interacting with tzdata
 RUN apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
         gcc \
         g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root
 
 SHELL [ "/bin/bash", "-c" ]
 
-ARG PYTHON_VERSION_TAG=3.8.1
+ARG PYTHON_VERSION_TAG=3.8.3
 ARG LINK_PYTHON_TO_PYTHON3=1
 
 # Existing lsb_release causes issues with modern installations of Python3

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,28 @@
 default: image
 
-all: image py_3.8.0 py_3.7.4 py_3.6.8
+all: image py_3.8.3 py_3.8.1 py_3.8.0 py_3.7.4 py_3.6.8
 
 image:
+	docker build . \
+	-f Dockerfile \
+	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
+	--build-arg PYTHON_VERSION_TAG=3.8.3 \
+	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
+	-t matthewfeickert/docker-python3-ubuntu:latest \
+	-t matthewfeickert/docker-python3-ubuntu:3.8.3 \
+	--compress
+
+py_3.8.3:
+	docker build . \
+	-f Dockerfile \
+	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
+	--build-arg PYTHON_VERSION_TAG=3.8.3 \
+	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
+	-t matthewfeickert/docker-python3-ubuntu:latest \
+	-t matthewfeickert/docker-python3-ubuntu:3.8.3 \
+	--compress
+
+py_3.8.1:
 	docker build -f Dockerfile \
 	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
 	--build-arg PYTHON_VERSION_TAG=3.8.1 \

--- a/install_python.sh
+++ b/install_python.sh
@@ -32,11 +32,14 @@ function build_cpython () {
     # https://github.com/python/cpython/blob/3.8/README.rst
     # https://github.com/python/cpython/blob/3.7/README.rst
     # https://github.com/python/cpython/blob/3.6/README.rst
+    printf "\n### ./configure --help\n"
+    ./configure --help
     printf "\n### ./configure\n"
     if [[ "${2}" > "3.7.0"  ]]; then
         # --with-threads is removed in Python 3.7 (threading already on)
         ./configure --prefix="${1}" \
             --exec_prefix="${1}" \
+            --with-ensurepip \
             --enable-optimizations \
             --with-lto \
             --enable-loadable-sqlite-extensions \
@@ -44,6 +47,7 @@ function build_cpython () {
     else
         ./configure --prefix="${1}" \
             --exec_prefix="${1}" \
+            --with-ensurepip \
             --enable-optimizations \
             --with-lto \
             --enable-loadable-sqlite-extensions \


### PR DESCRIPTION
Use [Python release 3.8.3](https://www.python.org/downloads/release/python-383/) as the default Python 3 Docker image.

Additionally add the `--with-ensurepip` flag for `configure` which has the following message:

```
$ ./configure --help | grep "pip"
  --with(out)-ensurepip=[=upgrade]
                          "install" or "upgrade" using bundled pip
```