### PR TITLE
feat: Update Python 3.8 to 3.8.7

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,7 +23,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/docker-python3-ubuntu
         dockerfile: Dockerfile
-        tags: latest,3.8.3
+        tags: latest,3.8.7
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /root
 
 SHELL [ "/bin/bash", "-c" ]
 
-ARG PYTHON_VERSION_TAG=3.8.3
+ARG PYTHON_VERSION_TAG=3.8.7
 ARG LINK_PYTHON_TO_PYTHON3=1
 
 # Existing lsb_release causes issues with modern installations of Python3

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,32 @@
 default: image
 
-all: image py_3.8.3 py_3.8.1 py_3.8.0 py_3.7.4 py_3.6.8
+all: image py_3.8.7 py_3.8.3 py_3.8.1 py_3.8.0 py_3.7.4 py_3.6.8
 
 image:
 	docker build . \
+	--pull \
 	-f Dockerfile \
 	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
-	--build-arg PYTHON_VERSION_TAG=3.8.3 \
+	--build-arg PYTHON_VERSION_TAG=3.8.7 \
 	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
 	-t matthewfeickert/docker-python3-ubuntu:latest \
-	-t matthewfeickert/docker-python3-ubuntu:3.8.3 \
+	-t matthewfeickert/docker-python3-ubuntu:3.8.7 \
+	--compress
+
+py_3.8.7:
+	docker build . \
+	--pull \
+	-f Dockerfile \
+	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
+	--build-arg PYTHON_VERSION_TAG=3.8.7 \
+	--build-arg LINK_PYTHON_TO_PYTHON3=1 \
+	-t matthewfeickert/docker-python3-ubuntu:latest \
+	-t matthewfeickert/docker-python3-ubuntu:3.8.7 \
 	--compress
 
 py_3.8.3:
 	docker build . \
+	--pull \
 	-f Dockerfile \
 	--cache-from matthewfeickert/docker-python3-ubuntu:latest \
 	--build-arg PYTHON_VERSION_TAG=3.8.3 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python3 on Ubuntu Docker
 
-Dockerfile for image built off [Ubuntu 20.04](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes/20.04) containing [Python 3.8](https://www.python.org/downloads/release/python-381/) ([Python 3.6](https://www.python.org/downloads/release/python-368/), [Python 3.7](https://www.python.org/downloads/release/python-374/)) built from source
+Dockerfile for image built off [Ubuntu 20.04](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes/20.04) containing [Python 3.8](https://www.python.org/downloads/release/python-387/) ([Python 3.6](https://www.python.org/downloads/release/python-368/), [Python 3.7](https://www.python.org/downloads/release/python-374/)) built from source
 
 [![GitHub Actions Status: CI](https://github.com/matthewfeickert/Docker-Python3-Ubuntu/workflows/CI/badge.svg?branch=master)](https://github.com/matthewfeickert/Docker-Python3-Ubuntu/actions?query=workflow%3ACI+branch%3Amaster)
 [![Docker Automated build](https://img.shields.io/docker/automated/matthewfeickert/docker-python3-ubuntu.svg)](https://hub.docker.com/r/matthewfeickert/docker-python3-ubuntu/)

--- a/install_python.sh
+++ b/install_python.sh
@@ -101,7 +101,7 @@ function main() {
     # 1: the Python version tag
     # 2: bool of if should symlink python and pip to python3 versions
 
-    PYTHON_VERSION_TAG=3.8.1
+    PYTHON_VERSION_TAG=3.8.7
     LINK_PYTHON_TO_PYTHON3=0 # By default don't link so as to reserve python for Python 2
     if [[ $# -gt 0 ]]; then
         PYTHON_VERSION_TAG="${1}"


### PR DESCRIPTION
Use [Python release 3.8.7](https://www.python.org/downloads/release/python-387/) as the default Python 3 Docker image.

Additionally add `--pull` to the Makefile targets.

```
* Update Python 3.8 to Python 3.8.7 as default version
   - c.f. https://www.python.org/downloads/release/python-387/
```