### PR TITLE
feat: Use `python3 -m pip` pattern for pip installs

### DIFF
--- a/install_python.sh
+++ b/install_python.sh
@@ -67,11 +67,11 @@ function update_pip {
     # Update pip, setuptools, and wheel
     if [[ "$(id -u)" -eq 0 ]]; then
         # If root
-        printf "\n### pip3 install --upgrade --no-cache-dir pip setuptools wheel\n"
-        pip3 install --upgrade --no-cache-dir pip setuptools wheel
+        printf "\n### python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel\n"
+        python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel
     else
-        printf "\n### pip3 install --user --upgrade --no-cache-dir pip setuptools wheel\n"
-        pip3 install --user --upgrade --no-cache-dir pip setuptools wheel
+        printf "\n### python3 -m pip --no-cache-dir install --user --upgrade pip setuptools wheel\n"
+        python3 -m pip --no-cache-dir install --user --upgrade pip setuptools wheel
     fi
 }
 


### PR DESCRIPTION
```
* Use 'python -m pip' in all cases to be sure that the pip being used
is the desired one.
```