### PR TITLE
fix: Truncate python3 version to simplify symlink logic

### DIFF
--- a/install_python.sh
+++ b/install_python.sh
@@ -80,7 +80,7 @@ function symlink_python_to_python3 {
     local python_version
     python_version="$(python3 --version)"
     local which_python
-    which_python="$(command -v python3)${python_version:8:2}"
+    which_python="$(command -v python3)${python_version:8:}"
     local which_pip
     which_pip="$(command -v pip3)"
 


### PR DESCRIPTION
* Instead of attempting to capture the minor version number just symlink to python3. This
allows for "${which_python::-1}" to easily resolve to 'python'.
* Amends PR #18