### PR TITLE
Set git attributes, so that the image can be built on Windows, too.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Without this fix, attempts to build on Windows systems cause `'\r': command not found` error, because of git's EOL management.